### PR TITLE
Auto Pop links

### DIFF
--- a/Examples/Demo/LinkDemo/ContentView.swift
+++ b/Examples/Demo/LinkDemo/ContentView.swift
@@ -13,38 +13,28 @@ import AppRouter
 struct ContentView: View {
 
     var body: some View {
-        RouterNavigationView(with: Router(state: Screen(count: 0)))
+        RouterNavigationView(with: Router(state: 0))
             .navigationViewStyle(StackNavigationViewStyle())
-    }
-}
-
-// Router state
-struct Screen: Equatable, Presentable, CustomDebugStringConvertible {
-    var count: Int
-    var presentation: PresentationType = .link
-
-    var debugDescription: String {
-        "Screen[\(count)]"
     }
 }
 
 /// Router implementation
 final class Router: AppRouting {
 
-    init(state: Screen, parent: Router? = nil) {
+    init(state: Int, parent: Router? = nil) {
         self.route = Route(state)
         self.parent = parent
     }
 
-    @Published var route: Route<Screen>
+    @Published var route: Route<Int>
     let parent: Router?
 
-    func makeChildRouter(state: Screen) -> Router {
+    func makeChildRouter(state: Int) -> Router {
         Router(state: state, parent: self)
     }
 
-    func makeContentView(state: Screen) -> some View {
-        CounterView(model: CounterViewModel(count: state.count))
+    func makeContentView(state: Int) -> some View {
+        CounterView(model: CounterViewModel(count: state))
     }
 }
 
@@ -53,12 +43,14 @@ extension Router {
 
     /// Move to the next screen with a increment.
     func next(_ inc: Int) {
-        state.count += inc
+        state += inc
     }
 
     /// Move to the previous screen, popping if appropriate.
     func previous() {
-        state = Screen(count: state.count - 1, presentation: .link(.autoPop))
+        transition(.link(.autoPop)) { state in
+            state -= 1
+        }
     }
 }
 
@@ -96,6 +88,7 @@ struct CounterView: View {
             Text(model.delayedMessage)
             Button(action: { router.next(1) }) { Text("Next +1") }
             Button(action: { router.next(2) }) { Text("Next +2") }
+            Button(action: { router.next(0) }) { Text("Next 0 (No Change)") }
             Button(action: { router.previous() }) { Text("Previous (AutoPop)") }
             Button(action: { router.pop() }) { Text("Back") }
             Button(action: { router.popToRoot() }) { Text("Back to Top") }

--- a/Examples/Demo/LinkDemo/ContentView.swift
+++ b/Examples/Demo/LinkDemo/ContentView.swift
@@ -13,28 +13,38 @@ import AppRouter
 struct ContentView: View {
 
     var body: some View {
-        RouterNavigationView(with: Router(state: 0))
+        RouterNavigationView(with: Router(state: Screen(count: 0)))
             .navigationViewStyle(StackNavigationViewStyle())
+    }
+}
+
+// Router state
+struct Screen: Equatable, Presentable, CustomDebugStringConvertible {
+    var count: Int
+    var presentation: PresentationType = .link
+
+    var debugDescription: String {
+        "Screen[\(count)]"
     }
 }
 
 /// Router implementation
 final class Router: AppRouting {
 
-    init(state: Int, parent: Router? = nil) {
+    init(state: Screen, parent: Router? = nil) {
         self.route = Route(state)
         self.parent = parent
     }
 
-    @Published var route: Route<Int>
+    @Published var route: Route<Screen>
     let parent: Router?
 
-    func makeChildRouter(state: Int) -> Router {
+    func makeChildRouter(state: Screen) -> Router {
         Router(state: state, parent: self)
     }
 
-    func makeContentView(state: Int) -> some View {
-        CounterView(model: CounterViewModel(count: state))
+    func makeContentView(state: Screen) -> some View {
+        CounterView(model: CounterViewModel(count: state.count))
     }
 }
 
@@ -43,7 +53,12 @@ extension Router {
 
     /// Move to the next screen with a increment.
     func next(_ inc: Int) {
-        state += inc
+        state.count += inc
+    }
+
+    /// Move to the previous screen, popping if appropriate.
+    func previous() {
+        state = Screen(count: state.count - 1, presentation: .link(.autoPop))
     }
 }
 
@@ -81,6 +96,7 @@ struct CounterView: View {
             Text(model.delayedMessage)
             Button(action: { router.next(1) }) { Text("Next +1") }
             Button(action: { router.next(2) }) { Text("Next +2") }
+            Button(action: { router.previous() }) { Text("Previous (AutoPop)") }
             Button(action: { router.pop() }) { Text("Back") }
             Button(action: { router.popToRoot() }) { Text("Back to Top") }
         }

--- a/Examples/Demo/SheetDemo/ContentView.swift
+++ b/Examples/Demo/SheetDemo/ContentView.swift
@@ -18,10 +18,9 @@ struct ContentView: View {
 }
 
 // Router state
-struct Screen: Equatable, Presentable, CustomDebugStringConvertible {
+struct Screen: Equatable, CustomDebugStringConvertible {
     var count: Int
     var message: String
-    var presentation: PresentationType = .link
 
     var debugDescription: String {
         "Screen[\(count)]"
@@ -53,19 +52,30 @@ final class Router: AppRouting {
 extension Router {
 
     func navigateTo(messsage: String) {
-        state = Screen(count: state.count + 1, message: messsage, presentation: .link)
+        transition(.link) { state in
+            state.count += 1
+            state.message = messsage
+        }
     }
 
     func showSheet(messsage: String) {
         if state.count >= 3 {
-            state = Screen(count: state.count + 1, message: messsage, presentation: .sheet)
+            transition(.sheet) { state in
+                state.count += 1
+                state.message = messsage
+            }
         } else {
-            state = Screen(count: state.count + 1, message: messsage, presentation: .sheet(.navigable))
+            transition(.sheet(.navigable)) { state in
+                state.count += 1
+                state.message = messsage
+            }
         }
     }
 
     func setRoot(_ multiplier: Int) {
-        state = Screen(count: state.count * multiplier, message: state.message, presentation: .root)
+        transition(.root) { state in
+            state.count *= multiplier
+        }
     }
 }
 

--- a/Examples/Demo/SheetDemo/ContentView.swift
+++ b/Examples/Demo/SheetDemo/ContentView.swift
@@ -18,7 +18,7 @@ struct ContentView: View {
 }
 
 // Router state
-struct Screen: Presentable, CustomDebugStringConvertible {
+struct Screen: Equatable, Presentable, CustomDebugStringConvertible {
     var count: Int
     var message: String
     var presentation: PresentationType = .link
@@ -60,7 +60,7 @@ extension Router {
         if state.count >= 3 {
             state = Screen(count: state.count + 1, message: messsage, presentation: .sheet)
         } else {
-            state = Screen(count: state.count + 1, message: messsage, presentation: .navigationSheet)
+            state = Screen(count: state.count + 1, message: messsage, presentation: .sheet(.navigable))
         }
     }
 

--- a/Examples/Demo/TabLinkDemo/ContentView.swift
+++ b/Examples/Demo/TabLinkDemo/ContentView.swift
@@ -106,15 +106,15 @@ final class Router: AppRouting {
 extension Router {
 
     func switchToHome() {
-        transition(.home(HomeState()), with: .root)
+        transition(.home(HomeState()), via: .root)
     }
 
     func switchToExplore() {
-        transition(.explore(ExploreState()), with: .root)
+        transition(.explore(ExploreState()), via: .root)
     }
 
     func switchToProfile() {
-        transition(.profile(ProfileState()), with: .root)
+        transition(.profile(ProfileState()), via: .root)
     }
 
     func switchToSettings() {

--- a/Examples/Demo/TabLinkDemo/ContentView.swift
+++ b/Examples/Demo/TabLinkDemo/ContentView.swift
@@ -39,15 +39,7 @@ enum Screen: Equatable {
     case settings(SettingsState)
 }
 
-extension Screen: CustomStringConvertible, Presentable {
-    var presentation: PresentationType {
-        switch self {
-        case .home: return .root
-        case .explore: return .root
-        case .profile: return .root
-        case .settings: return .link
-        }
-    }
+extension Screen: CustomStringConvertible {
     var description: String {
         switch self {
         case .home: return "home"
@@ -114,15 +106,15 @@ final class Router: AppRouting {
 extension Router {
 
     func switchToHome() {
-        state = .home(HomeState())
+        transition(.home(HomeState()), with: .root)
     }
 
     func switchToExplore() {
-        state = .explore(ExploreState())
+        transition(.explore(ExploreState()), with: .root)
     }
 
     func switchToProfile() {
-        state = .profile(ProfileState())
+        transition(.profile(ProfileState()), with: .root)
     }
 
     func switchToSettings() {

--- a/Examples/Demo/TabLinkDemo/ContentView.swift
+++ b/Examples/Demo/TabLinkDemo/ContentView.swift
@@ -32,7 +32,7 @@ struct ContentView: View {
 }
 
 /// The State type
-enum Screen {
+enum Screen: Equatable {
     case home(HomeState)
     case explore(ExploreState)
     case profile(ProfileState)
@@ -59,19 +59,19 @@ extension Screen: CustomStringConvertible, Presentable {
 }
 
 /// Sub-states for each screen
-struct HomeState {
+struct HomeState: Equatable {
     var tab: Tab { .home }
 }
 
-struct ExploreState {
+struct ExploreState: Equatable {
     var tab: Tab { .explore }
 }
 
-struct ProfileState {
+struct ProfileState: Equatable {
     var tab: Tab { .profile }
 }
 
-struct SettingsState {
+struct SettingsState: Equatable {
     var tab: Tab { .profile }
 }
 

--- a/Sources/AppRouter/AppRouter.swift
+++ b/Sources/AppRouter/AppRouter.swift
@@ -16,6 +16,13 @@ public protocol AppRouting: ObservableObject {
     func makeContentView(state: State) -> Content
 }
 
+/// Adopt this protocol to change how state transitions are presented by default.
+public protocol Presentable {
+
+    /// Return the default presentation for state transitions.
+    var defaultPresentation: PresentationType { get }
+}
+
 public extension AppRouting {
 
     /// Get the current router state.
@@ -23,7 +30,7 @@ public extension AppRouting {
     /// Setting the state transitions with default presentation.
     var state: State {
         get { route.current }
-        set { transition(newValue, via: .default) }
+        set { transition(newValue, via: defaultPresentation) }
     }
 
     /// Transition to state with presentation.
@@ -120,6 +127,14 @@ internal extension AppRouting {
         var stack: [NestedRouter] = [self]
         while let p = stack.last?.parent { stack.append(p) }
         return stack
+    }
+
+    var defaultPresentation: PresentationType {
+        if let p = self as? Presentable {
+            return p.defaultPresentation
+        } else {
+            return .default
+        }
     }
 }
 

--- a/Sources/AppRouter/AppRouter.swift
+++ b/Sources/AppRouter/AppRouter.swift
@@ -27,16 +27,9 @@ public extension AppRouting {
         }
         set {
             if let pState = newValue as? Presentable {
-                switch pState.presentation {
-                case .link, .sheet, .navigationSheet:
-                    route.push(state: newValue, presentation: pState.presentation)
-                case .replace:
-                    route = Route(newValue)
-                case .root:
-                    rootRouter.route = Route(newValue)
-                }
+                pState.presentation.route(self, to: newValue)
             } else {
-                route.push(state: newValue, presentation: .link)
+                PresentationType.link.route(self, to: newValue)
             }
         }
     }
@@ -55,33 +48,6 @@ public extension AppRouting {
         rootRouter.route.pop()
 
     }
-}
-
-/// The suppored types of presentation.
-public enum PresentationType {
-
-    /// Present the state via NavigationLink.
-    case link
-
-    /// Present the state via sheet().
-    case sheet
-
-    /// Present the state via sheet(), embedding content in a NavigationView.
-    case navigationSheet
-
-    /// Replace the current base state, instead of pushing a new state.
-    case replace
-
-    /// Replace the root router's base state, popping all children.
-    case root
-}
-
-/// If your router's State adopts this protocol it can control how
-/// the pushed state is presented.
-public protocol Presentable {
-
-    /// The presentation to use for pushed state.
-    var presentation: PresentationType { get }
 }
 
 public struct Route<State> {

--- a/Sources/AppRouter/AppRouter.swift
+++ b/Sources/AppRouter/AppRouter.swift
@@ -127,7 +127,7 @@ fileprivate extension PresentationType {
 
     var isSheet: Bool {
         switch self {
-        case .sheet, .navigationSheet: return true
+        case .sheet: return true
         default: return false
         }
     }

--- a/Sources/AppRouter/AppRouter.swift
+++ b/Sources/AppRouter/AppRouter.swift
@@ -26,13 +26,9 @@ public extension AppRouting {
             route.current
         }
         set {
-            if newValue == route.current {
-                return
-            }
-            if let pState = newValue as? Presentable {
-                pState.presentation.route(self, to: newValue)
-            } else {
-                PresentationType.link.route(self, to: newValue)
+            if newValue != route.current {
+                let presentation = (newValue as? Presentable)?.presentation ?? .default
+                presentation.route(self, to: newValue)
             }
         }
     }
@@ -94,7 +90,7 @@ internal extension Route {
 internal extension AppRouting {
 
     var isLinkActiveBinding: Binding<Bool> {
-        Binding(get: { self.route.pushed?.presentation == .link },
+        Binding(get: { self.route.pushed?.presentation.isLink ?? false },
                 set: { if !$0 { self.route.pop() } })
     }
 
@@ -120,15 +116,19 @@ internal extension AppRouting {
     }
 }
 
-internal extension PresentationType {
+fileprivate extension PresentationType {
+
+    var isLink: Bool {
+        switch self {
+        case .link: return true
+        default: return false
+        }
+    }
 
     var isSheet: Bool {
         switch self {
         case .sheet, .navigationSheet: return true
-        case .link: return false
-        case .replace: return false
-        case .root: return false
+        default: return false
         }
     }
 }
-

--- a/Sources/AppRouter/AppRouter.swift
+++ b/Sources/AppRouter/AppRouter.swift
@@ -23,11 +23,11 @@ public extension AppRouting {
     /// Setting the state transitions with default presentation.
     var state: State {
         get { route.current }
-        set { transition(newValue, with: .default) }
+        set { transition(newValue, via: .default) }
     }
 
     /// Transition to state with presentation.
-    func transition(_ state: State, with presentation: PresentationType) {
+    func transition(_ state: State, via presentation: PresentationType) {
         presentation.route(self, to: state)
     }
 

--- a/Sources/AppRouter/AppRouter.swift
+++ b/Sources/AppRouter/AppRouter.swift
@@ -20,17 +20,22 @@ public extension AppRouting {
 
     /// Get the current router state.
     ///
-    /// Setting the state modifies the pushed state.
+    /// Setting the state transitions with default presentation.
     var state: State {
-        get {
-            route.current
-        }
-        set {
-            if newValue != route.current {
-                let presentation = (newValue as? Presentable)?.presentation ?? .default
-                presentation.route(self, to: newValue)
-            }
-        }
+        get { route.current }
+        set { transition(newValue, with: .default) }
+    }
+
+    /// Transition to state with presentation.
+    func transition(_ state: State, with presentation: PresentationType) {
+        presentation.route(self, to: state)
+    }
+
+    /// Transition via presentation, modifying state with closure.
+    func transition(_ presentation: PresentationType, modify: (inout State) -> Void) {
+        var newState = state
+        modify(&newState)
+        presentation.route(self, to: newState)
     }
 
     /// Pop one level.

--- a/Sources/AppRouter/AppRouter.swift
+++ b/Sources/AppRouter/AppRouter.swift
@@ -32,11 +32,13 @@ public extension AppRouting {
     }
 
     /// Transition via presentation, modifying state with closure.
-    func transition(_ presentation: PresentationType, modify: (inout State) -> Void) {
+    func transition<Out>(_ presentation: PresentationType, modify: (inout State) throws -> Out) rethrows -> Out {
         var newState = state
-        modify(&newState)
+        let output = try modify(&newState)
         presentation.route(self, to: newState)
+        return output
     }
+
 
     /// Pop one level.
     func pop() {

--- a/Sources/AppRouter/AppRouter.swift
+++ b/Sources/AppRouter/AppRouter.swift
@@ -26,6 +26,9 @@ public extension AppRouting {
             route.current
         }
         set {
+            if newValue == route.current {
+                return
+            }
             if let pState = newValue as? Presentable {
                 pState.presentation.route(self, to: newValue)
             } else {

--- a/Sources/AppRouter/AppRouter.swift
+++ b/Sources/AppRouter/AppRouter.swift
@@ -7,7 +7,7 @@
 import SwiftUI
 
 public protocol AppRouting: ObservableObject {
-    associatedtype State
+    associatedtype State: Equatable
     associatedtype Content: View
     associatedtype NestedRouter: AppRouting where NestedRouter == Self
     var route: Route<State> { get set }

--- a/Sources/AppRouter/Presentation.swift
+++ b/Sources/AppRouter/Presentation.swift
@@ -19,7 +19,7 @@ public protocol Presentable {
 public struct LinkOptions: Equatable {
 
     /// Enable autoPop for links.
-    static var autoPop: Self { .init(autoPopToPreviousState: true) }
+    public static var autoPop: Self { .init(autoPopToPreviousState: true) }
 
     /// If a link would move to the previous state, the router
     /// automatically pops the current state instead of pushing a new state.
@@ -28,6 +28,9 @@ public struct LinkOptions: Equatable {
 
 /// The supported types of presentation.
 public enum PresentationType: Equatable {
+
+    /// The default presentation.
+    public static var `default`: Self { .link }
 
     /// Present the state via NavigationLink, with default link options.
     public static var link: Self { .link(LinkOptions()) }

--- a/Sources/AppRouter/Presentation.swift
+++ b/Sources/AppRouter/Presentation.swift
@@ -1,0 +1,93 @@
+//
+//  File.swift
+//  
+//
+//  Created by Ryan Carver on 2/26/21.
+//
+
+import Foundation
+
+/// If your router's State adopts this protocol it can control how
+/// the pushed state is presented.
+public protocol Presentable {
+
+    /// The presentation to use for pushed state.
+    var presentation: PresentationType { get }
+}
+
+/// Options for the behvior of presenting via link.
+public struct LinkOptions: Equatable {
+
+    static var autoPop: Self { .init(autoPopToPreviousState: true) }
+
+    /// If a link would move to the previous state, the router
+    /// automatically pops the current state instead of pushing a new state.
+    var autoPopToPreviousState: Bool = false
+}
+
+/// The supported types of presentation.
+public enum PresentationType: Equatable {
+
+    /// Present the state via NavigationLink, with default link options.
+    public static var link: Self { .link(LinkOptions()) }
+
+    /// Present the state via NavigationLink, with link options.
+    case link(LinkOptions)
+
+    /// Present the state via sheet().
+    case sheet
+
+    /// Present the state via sheet(), embedding content in a NavigationView.
+    case navigationSheet
+
+    /// Replace the current base state, instead of pushing a new state.
+    case replace
+
+    /// Replace the root router's base state, popping all children.
+    case root
+}
+
+extension PresentationType: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .link(_):
+            return "link"
+        case .sheet:
+            return "sheet"
+        case .navigationSheet:
+            return "navigationSheet"
+        case .replace:
+            return "replace"
+        case .root:
+            return "root"
+        }
+    }
+}
+
+extension PresentationType {
+
+    func route<Router: AppRouting>(_ router: Router, to state: Router.State) {
+        switch self {
+
+        case .link(let options):
+            if options.autoPopToPreviousState {
+                if let previous = router.parent?.route.base, previous == state {
+                    router.pop()
+                } else {
+                    router.route.push(state: state, presentation: self)
+                }
+            } else {
+                router.route.push(state: state, presentation: self)
+            }
+
+        case .sheet, .navigationSheet:
+            router.route.push(state: state, presentation: self)
+
+        case .replace:
+            router.route = Route(state)
+
+        case .root:
+            router.rootRouter.route = Route(state)
+        }
+    }
+}

--- a/Sources/AppRouter/Presentation.swift
+++ b/Sources/AppRouter/Presentation.swift
@@ -7,14 +7,6 @@
 
 import Foundation
 
-/// If your router's State adopts this protocol it can control how
-/// the pushed state is presented.
-public protocol Presentable {
-
-    /// The presentation to use for pushed state.
-    var presentation: PresentationType { get }
-}
-
 /// Options for presenting as link.
 public struct LinkOptions: Equatable {
 
@@ -83,6 +75,9 @@ extension PresentationType {
         switch self {
 
         case .link(let options):
+            if state == router.route.current {
+                return
+            }
             if options.autoPopToPreviousState {
                 if let previous = router.parent?.route.base, previous == state {
                     router.pop()
@@ -94,6 +89,9 @@ extension PresentationType {
             }
 
         case .sheet:
+            if state == router.route.current {
+                return
+            }
             router.route.push(state: state, presentation: self)
 
         case .replace:

--- a/Sources/AppRouter/Presentation.swift
+++ b/Sources/AppRouter/Presentation.swift
@@ -15,7 +15,7 @@ public protocol Presentable {
     var presentation: PresentationType { get }
 }
 
-/// Options for the behvior of presenting via link.
+/// Options for presenting as link.
 public struct LinkOptions: Equatable {
 
     /// Enable autoPop for links.
@@ -24,6 +24,17 @@ public struct LinkOptions: Equatable {
     /// If a link would move to the previous state, the router
     /// automatically pops the current state instead of pushing a new state.
     var autoPopToPreviousState: Bool = false
+}
+
+/// Options for presenting as sheet.
+public struct SheetOptions: Equatable {
+
+    /// Enable navigation for the content.
+    public static var navigable: Self { .init(makeContentNavigable: true) }
+
+    /// If true, the presented content will be wrapped in a Router-connected
+    /// NavigationView. False presents the content as-is.
+    var makeContentNavigable: Bool = false
 }
 
 /// The supported types of presentation.
@@ -35,14 +46,14 @@ public enum PresentationType: Equatable {
     /// Present the state via NavigationLink, with default link options.
     public static var link: Self { .link(LinkOptions()) }
 
+    /// Present the state via sheet, with default options.
+    public static var sheet: Self { .sheet(SheetOptions()) }
+
     /// Present the state via NavigationLink, with link options.
     case link(LinkOptions)
 
-    /// Present the state via sheet().
-    case sheet
-
-    /// Present the state via sheet(), embedding content in a NavigationView.
-    case navigationSheet
+    /// Present the state via sheet, with sheet options.
+    case sheet(SheetOptions)
 
     /// Replace the current base state, instead of pushing a new state.
     case replace
@@ -56,10 +67,8 @@ extension PresentationType: CustomStringConvertible {
         switch self {
         case .link(_):
             return "link"
-        case .sheet:
+        case .sheet(_):
             return "sheet"
-        case .navigationSheet:
-            return "navigationSheet"
         case .replace:
             return "replace"
         case .root:
@@ -84,7 +93,7 @@ extension PresentationType {
                 router.route.push(state: state, presentation: self)
             }
 
-        case .sheet, .navigationSheet:
+        case .sheet:
             router.route.push(state: state, presentation: self)
 
         case .replace:

--- a/Sources/AppRouter/Presentation.swift
+++ b/Sources/AppRouter/Presentation.swift
@@ -18,6 +18,7 @@ public protocol Presentable {
 /// Options for the behvior of presenting via link.
 public struct LinkOptions: Equatable {
 
+    /// Enable autoPop for links.
     static var autoPop: Self { .init(autoPopToPreviousState: true) }
 
     /// If a link would move to the previous state, the router

--- a/Sources/AppRouter/TestHarness.swift
+++ b/Sources/AppRouter/TestHarness.swift
@@ -37,7 +37,7 @@ enum TestHarness {
         }
 
         func nextSheet() {
-            state = State(count: state.count + 1, presentation: .navigationSheet)
+            state = State(count: state.count + 1, presentation: .sheet(.navigable))
         }
 
         func nextLink() {

--- a/Sources/AppRouter/TestHarness.swift
+++ b/Sources/AppRouter/TestHarness.swift
@@ -9,9 +9,8 @@ import SwiftUI
 
 enum TestHarness {
 
-    struct State: Equatable, Presentable, CustomDebugStringConvertible {
+    struct State: Equatable, CustomDebugStringConvertible {
         var count: Int
-        var presentation: PresentationType = .link
 
         var debugDescription: String {
             "State[\(count)]"
@@ -37,19 +36,33 @@ enum TestHarness {
         }
 
         func nextSheet() {
-            state = State(count: state.count + 1, presentation: .sheet(.navigable))
+            transition(.sheet(.navigable)) { state in
+                state.count += 1
+            }
         }
 
         func nextLink() {
-            state = State(count: state.count + 1, presentation: .link)
+            transition(.link) { state in
+                state.count += 1
+            }
+        }
+
+        func previousAutoPop() {
+            transition(.link(.autoPop)) { state in
+                state.count -= 1
+            }
         }
 
         func nextReplace(_ multiplier: Int) {
-            state = State(count: state.count * multiplier, presentation: .replace)
+            transition(.replace) { state in
+                state.count *= multiplier
+            }
         }
 
         func nextRoot(_ inc: Int) {
-            state = State(count: state.count + inc, presentation: .root)
+            transition(.root) { state in
+                state.count += inc
+            }
         }
     }
 
@@ -59,6 +72,7 @@ enum TestHarness {
         var body: some View {
             VStack {
                 Button(action: { router.nextLink() }) { Text("Link") }
+                Button(action: { router.previousAutoPop() }) { Text("AutoPop") }
                 Button(action: { router.nextSheet() }) { Text("Sheet") }
                 Button(action: { router.nextReplace(10) }) { Text("Replace x10") }
                 Button(action: { router.nextRoot(5) }) { Text("Root +5") }

--- a/Sources/AppRouter/TestHarness.swift
+++ b/Sources/AppRouter/TestHarness.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 enum TestHarness {
 
-    struct State: Presentable, CustomDebugStringConvertible {
+    struct State: Equatable, Presentable, CustomDebugStringConvertible {
         var count: Int
         var presentation: PresentationType = .link
 

--- a/Sources/AppRouter/Views.swift
+++ b/Sources/AppRouter/Views.swift
@@ -109,10 +109,12 @@ struct PushedStateView<Router: AppRouting, Content: View>: View {
         let view = FullyRoutedView(router: child)
 
         switch pushed.presentation {
-        case .navigationSheet:
-            return AnyView(NavigationView { view })
-        case .sheet:
-            return AnyView(view)
+        case .sheet(let options):
+            if options.makeContentNavigable {
+                return AnyView(NavigationView { view })
+            } else {
+                return AnyView(view)
+            }
         case .link:
             return AnyView(view)
         case .replace, .root:

--- a/Tests/AppRouterTests/AppRouterTests.swift
+++ b/Tests/AppRouterTests/AppRouterTests.swift
@@ -159,3 +159,35 @@ class AppRoutingTests: XCTestCase {
         XCTAssertEqual(parent.route, Route(0))
     }
 }
+
+class PresentableTests: XCTestCase {
+
+    final class PresentableRouter: AppRouting, Presentable {
+
+        internal init(state: Int, parent: PresentableRouter? = nil) {
+            self.route = Route(state)
+            self.parent = parent
+        }
+
+        var route: Route<Int>
+        var parent: PresentableRouter?
+
+        var defaultPresentation: PresentationType { .sheet }
+
+        func makeChildRouter(state: Int) -> PresentableRouter {
+            PresentableRouter(state: state, parent: self)
+        }
+
+        func makeContentView(state: Int) -> some View {
+            Text("Hello \(state)")
+        }
+    }
+
+    func test_defaultPresentation() {
+        let parent = PresentableRouter(state: 0)
+
+        parent.state = 3
+
+        XCTAssertEqual(parent.route, Route(base: 0, pushed: 3, presentation: .sheet))
+    }
+}

--- a/Tests/AppRouterTests/AppRouterTests.swift
+++ b/Tests/AppRouterTests/AppRouterTests.swift
@@ -128,4 +128,34 @@ class AppRoutingTests: XCTestCase {
 
         XCTAssertEqual(parent.route, Route(base: 0, pushed: 2, presentation: .sheet))
     }
+
+    func test_transition_closure_return() {
+        let parent = TestRouter(state: 0)
+
+        let result = parent.transition(.sheet) { state -> String in
+            state += 2
+            return "OK"
+        }
+
+        XCTAssertEqual(result, "OK")
+        XCTAssertEqual(parent.route, Route(base: 0, pushed: 2, presentation: .sheet))
+    }
+
+    func test_transition_closure_throws() {
+        let parent = TestRouter(state: 0)
+
+        struct Err: Error, Equatable {}
+
+        do {
+            try parent.transition(.sheet) { state in
+                state += 2
+                throw Err()
+            }
+            XCTFail("should throw")
+        } catch {
+            XCTAssertEqual(error as? Err, Err())
+        }
+
+        XCTAssertEqual(parent.route, Route(0))
+    }
 }

--- a/Tests/AppRouterTests/AppRouterTests.swift
+++ b/Tests/AppRouterTests/AppRouterTests.swift
@@ -47,12 +47,6 @@ class AppRoutingTests: XCTestCase {
         XCTAssertEqual(parent.route, Route(0), "parent drops push")
     }
 
-    func test_push_route_duplicate_state() {
-        let parent = TestRouter(state: 0)
-        parent.state = 0
-        XCTAssertEqual(parent.route, Route(0))
-    }
-
     func test_push_route_state_to_child() throws {
         let parent = TestRouter(state: 0)
         parent.state = 1

--- a/Tests/AppRouterTests/AppRouterTests.swift
+++ b/Tests/AppRouterTests/AppRouterTests.swift
@@ -47,6 +47,12 @@ class AppRoutingTests: XCTestCase {
         XCTAssertEqual(parent.route, Route(0), "parent drops push")
     }
 
+    func test_push_route_duplicate_state() {
+        let parent = TestRouter(state: 0)
+        parent.state = 0
+        XCTAssertEqual(parent.route, Route(0))
+    }
+
     func test_push_route_state_to_child() throws {
         let parent = TestRouter(state: 0)
         parent.state = 1

--- a/Tests/AppRouterTests/AppRouterTests.swift
+++ b/Tests/AppRouterTests/AppRouterTests.swift
@@ -110,4 +110,22 @@ class AppRoutingTests: XCTestCase {
         XCTAssertEqual(child2.route, Route(base: 2, pushed: 3, presentation: .link), "intermediate children are unaffected")
         XCTAssertEqual(child3.route, Route(3), "orphaned push is dropped")
     }
+
+    func test_transition() {
+        let parent = TestRouter(state: 0)
+
+        parent.transition(1, via: .sheet)
+
+        XCTAssertEqual(parent.route, Route(base: 0, pushed: 1, presentation: .sheet))
+    }
+
+    func test_transition_closure() {
+        let parent = TestRouter(state: 0)
+
+        parent.transition(.sheet) { state in
+            state += 2
+        }
+
+        XCTAssertEqual(parent.route, Route(base: 0, pushed: 2, presentation: .sheet))
+    }
 }

--- a/Tests/AppRouterTests/PresentationTests.swift
+++ b/Tests/AppRouterTests/PresentationTests.swift
@@ -11,42 +11,18 @@ import SwiftUI
 
 class PresentationTests: XCTestCase {
 
-    struct State: Equatable, Presentable {
-        var count: Int
-        var presentation: PresentationType = .link
-    }
-
     final class TestRouter: AppRouting {
 
-        internal init(state: State, parent: TestRouter? = nil) {
-            self.route = Route(state)
-            self.parent = parent
-        }
-
-        var route: Route<State>
-        var parent: TestRouter?
-
-        func makeChildRouter(state: State) -> TestRouter {
-            TestRouter(state: state, parent: self)
-        }
-
-        func makeContentView(state: State) -> some View {
-            Text("Hello \(state.count)")
-        }
-    }
-
-    final class IntRouter: AppRouting {
-
-        internal init(state: Int, parent: IntRouter? = nil) {
+        internal init(state: Int, parent: TestRouter? = nil) {
             self.route = Route(state)
             self.parent = parent
         }
 
         var route: Route<Int>
-        var parent: IntRouter?
+        var parent: TestRouter?
 
-        func makeChildRouter(state: Int) -> IntRouter {
-            IntRouter(state: state, parent: self)
+        func makeChildRouter(state: Int) -> TestRouter {
+            TestRouter(state: state, parent: self)
         }
 
         func makeContentView(state: Int) -> some View {
@@ -58,15 +34,23 @@ class PresentationTests: XCTestCase {
 extension PresentationTests {
 
     func test_route_link() {
-        let parent = IntRouter(state: 0)
+        let parent = TestRouter(state: 0)
 
         PresentationType.link.route(parent, to: 1)
 
         XCTAssertEqual(parent.route, Route(base: 0, pushed: 1, presentation: .link))
     }
 
+    func test_route_link_same_state() {
+        let parent = TestRouter(state: 0)
+
+        PresentationType.link.route(parent, to: 0)
+
+        XCTAssertEqual(parent.route, Route(0))
+    }
+
     func test_route_link_autoPop() throws {
-        let parent = IntRouter(state: 0)
+        let parent = TestRouter(state: 0)
 
         PresentationType.link.route(parent, to: 1)
         let child1 = parent.makeChildRouter(state: try XCTUnwrap(parent.route.pushed?.state))
@@ -89,15 +73,23 @@ extension PresentationTests {
     }
 
     func test_route_sheet() {
-        let parent = IntRouter(state: 0)
+        let parent = TestRouter(state: 0)
 
         PresentationType.sheet.route(parent, to: 1)
 
         XCTAssertEqual(parent.route, Route(base: 0, pushed: 1, presentation: .sheet))
     }
 
+    func test_route_sheet_same_state() {
+        let parent = TestRouter(state: 0)
+
+        PresentationType.sheet.route(parent, to: 0)
+
+        XCTAssertEqual(parent.route, Route(0))
+    }
+
     func test_route_replace() throws {
-        let parent = IntRouter(state: 0)
+        let parent = TestRouter(state: 0)
 
         PresentationType.link.route(parent, to: 1)
 
@@ -113,7 +105,7 @@ extension PresentationTests {
     }
 
     func test_route_root() throws {
-        let parent = IntRouter(state: 0)
+        let parent = TestRouter(state: 0)
 
         PresentationType.link.route(parent, to: 1)
 

--- a/Tests/AppRouterTests/PresentationTests.swift
+++ b/Tests/AppRouterTests/PresentationTests.swift
@@ -96,14 +96,6 @@ extension PresentationTests {
         XCTAssertEqual(parent.route, Route(base: 0, pushed: 1, presentation: .sheet))
     }
 
-    func test_route_navigationSheet() {
-        let parent = IntRouter(state: 0)
-
-        PresentationType.navigationSheet.route(parent, to: 1)
-
-        XCTAssertEqual(parent.route, Route(base: 0, pushed: 1, presentation: .navigationSheet))
-    }
-
     func test_route_replace() throws {
         let parent = IntRouter(state: 0)
 

--- a/Tests/AppRouterTests/PresentationTests.swift
+++ b/Tests/AppRouterTests/PresentationTests.swift
@@ -1,0 +1,138 @@
+//
+//  Test.m
+//  
+//
+//  Created by Ryan Carver on 2/26/21.
+//
+
+import XCTest
+import SwiftUI
+@testable import AppRouter
+
+class PresentationTests: XCTestCase {
+
+    struct State: Equatable, Presentable {
+        var count: Int
+        var presentation: PresentationType = .link
+    }
+
+    final class TestRouter: AppRouting {
+
+        internal init(state: State, parent: TestRouter? = nil) {
+            self.route = Route(state)
+            self.parent = parent
+        }
+
+        var route: Route<State>
+        var parent: TestRouter?
+
+        func makeChildRouter(state: State) -> TestRouter {
+            TestRouter(state: state, parent: self)
+        }
+
+        func makeContentView(state: State) -> some View {
+            Text("Hello \(state.count)")
+        }
+    }
+
+    final class IntRouter: AppRouting {
+
+        internal init(state: Int, parent: IntRouter? = nil) {
+            self.route = Route(state)
+            self.parent = parent
+        }
+
+        var route: Route<Int>
+        var parent: IntRouter?
+
+        func makeChildRouter(state: Int) -> IntRouter {
+            IntRouter(state: state, parent: self)
+        }
+
+        func makeContentView(state: Int) -> some View {
+            Text("Hello \(state)")
+        }
+    }
+}
+
+extension PresentationTests {
+
+    func test_route_link() {
+        let parent = IntRouter(state: 0)
+
+        PresentationType.link.route(parent, to: 1)
+
+        XCTAssertEqual(parent.route, Route(base: 0, pushed: 1, presentation: .link))
+    }
+
+    func test_route_link_autoPop() throws {
+        let parent = IntRouter(state: 0)
+
+        PresentationType.link.route(parent, to: 1)
+        let child1 = parent.makeChildRouter(state: try XCTUnwrap(parent.route.pushed?.state))
+
+        XCTAssertEqual(parent.route, Route(base: 0, pushed: 1, presentation: .link))
+        XCTAssertEqual(child1.route, Route(1))
+
+        PresentationType.link(.autoPop).route(child1, to: 2)
+        let child2 = child1.makeChildRouter(state: try XCTUnwrap(child1.route.pushed?.state))
+
+        XCTAssertEqual(parent.route, Route(base: 0, pushed: 1, presentation: .link))
+        XCTAssertEqual(child1.route, Route(base: 1, pushed: 2, presentation: .link(.autoPop)))
+        XCTAssertEqual(child2.route, Route(2))
+
+        PresentationType.link(.autoPop).route(child2, to: 1)
+
+        XCTAssertEqual(parent.route, Route(base: 0, pushed: 1, presentation: .link))
+        XCTAssertEqual(child1.route, Route(1))
+        XCTAssertEqual(child2.route, Route(2))
+    }
+
+    func test_route_sheet() {
+        let parent = IntRouter(state: 0)
+
+        PresentationType.sheet.route(parent, to: 1)
+
+        XCTAssertEqual(parent.route, Route(base: 0, pushed: 1, presentation: .sheet))
+    }
+
+    func test_route_navigationSheet() {
+        let parent = IntRouter(state: 0)
+
+        PresentationType.navigationSheet.route(parent, to: 1)
+
+        XCTAssertEqual(parent.route, Route(base: 0, pushed: 1, presentation: .navigationSheet))
+    }
+
+    func test_route_replace() throws {
+        let parent = IntRouter(state: 0)
+
+        PresentationType.link.route(parent, to: 1)
+
+        let child = parent.makeChildRouter(state: try XCTUnwrap(parent.route.pushed?.state))
+
+        XCTAssertEqual(parent.route, Route(base: 0, pushed: 1, presentation: .link))
+        XCTAssertEqual(child.route, Route(1))
+
+        PresentationType.replace.route(child, to: 2)
+
+        XCTAssertEqual(parent.route, Route(base: 0, pushed: 1, presentation: .link))
+        XCTAssertEqual(child.route, Route(2))
+    }
+
+    func test_route_root() throws {
+        let parent = IntRouter(state: 0)
+
+        PresentationType.link.route(parent, to: 1)
+
+        let child = parent.makeChildRouter(state: try XCTUnwrap(parent.route.pushed?.state))
+
+        XCTAssertEqual(parent.route, Route(base: 0, pushed: 1, presentation: .link))
+        XCTAssertEqual(child.route, Route(1))
+
+        PresentationType.root.route(child, to: 2)
+
+        XCTAssertEqual(parent.route, Route(2))
+        XCTAssertEqual(child.route, Route(1))
+    }
+}


### PR DESCRIPTION
This adds logic for links presentation to:

1. Don't push if the state is equal
2. Optionally pop the state if the new state equals the previous state (auto pop)

Breaking Changes
* State now requires Equatable conformance
* `Presentable` protocol is removed, removing presentation from State. Use `router.transition` instead
* `Presentable` protocol is  added, now for use on a Router to set the default presentation for state change