### PR TITLE
Transition events for StackRouter

### DIFF
--- a/Examples/Demo/LinkDemo/ContentView.swift
+++ b/Examples/Demo/LinkDemo/ContentView.swift
@@ -29,6 +29,8 @@ final class Router: StackRouting {
     @Published var route: StackRoute<Int>
     let parent: Router?
 
+    var transition: (Int, Int) -> Void { stackDidTransition }
+
     func makeChildRouter(state: Int) -> Router {
         Router(state: state, parent: self)
     }
@@ -52,6 +54,10 @@ extension Router {
             state -= 1
         }
     }
+}
+
+func stackDidTransition(from oldState: Int, to newState: Int) {
+    print("Stack transition from:\(oldState) to:\(newState)")
 }
 
 class CounterViewModel: ObservableObject {

--- a/Examples/Demo/TabDemo/ContentView.swift
+++ b/Examples/Demo/TabDemo/ContentView.swift
@@ -39,6 +39,8 @@ final class TabRouter: TabRouting, ObservableObject {
 
     @Published var route: TabRoute<Tab>
 
+    var transition: Transition { tabDidTransition }
+
     private var tabRouters: [ Tab : NavRouter ] = [:]
 
     func getStackRouter(tab: Tab) -> NavRouter {
@@ -69,10 +71,14 @@ final class TabRouter: TabRouting, ObservableObject {
             }
         }
     }
+}
 
-    func tabDidTransition(from oldTab: Tab, to newTab: Tab, with behavior: TabBehavior) {
-        print("Tab transition from:\(oldTab) to:\(newTab)")
-    }
+func tabDidTransition(from oldTab: Tab, to newTab: Tab, with behavior: TabBehavior) {
+    print("Tab transition from:\(oldTab) to:\(newTab) (\(behavior))")
+}
+
+func stackDidTransition(from oldState: Int, to newState: Int) {
+    print("Stack transition from:\(oldState) to:\(newState)")
 }
 
 extension TabRouter: TabBehaving {
@@ -101,6 +107,9 @@ final class NavRouter: StackRouting {
     }
 
     @Published var route: StackRoute<Int>
+
+    var transition: (Int, Int) -> Void { stackDidTransition }
+
     var parent: NavRouter?
 
     func makeChildRouter(state: Int) -> NavRouter {

--- a/Sources/AppRouter/StackRouter.swift
+++ b/Sources/AppRouter/StackRouter.swift
@@ -169,12 +169,23 @@ internal extension StackRouting {
 
     var isLinkActiveBinding: Binding<Bool> {
         Binding(get: { self.route.pushed?.presentation.isLink ?? false },
-                set: { if !$0 { self.route.pop() } })
+                set: { if !$0 { self.popViaBinding() } })
     }
 
     var isSheetPresentedBinding: Binding<Bool> {
         Binding(get: { self.route.pushed?.presentation.isSheet ?? false },
-                set: { if !$0 { self.route.pop() } })
+                set: { if !$0 { self.popViaBinding() } })
+    }
+
+    /// When called from a views binding, we're in the *parent* router,
+    /// so calling parent.pop() causes recursion.
+    func popViaBinding() {
+        let oldState = self.state
+        route.pop()
+        let newState = self.state
+        if oldState != newState {
+            transition(oldState, newState)
+        }
     }
 
     var objectAddress: String {

--- a/Sources/AppRouter/StackRouter.swift
+++ b/Sources/AppRouter/StackRouter.swift
@@ -20,6 +20,9 @@ public protocol StackRouting: ObservableObject {
     /// A self-referential type for parent/child router relationships.
     associatedtype NestedRouter: StackRouting where NestedRouter == Self
 
+    /// A function that receives (oldState, newState) whenever the state changes.
+    typealias Transition = (State, State) -> Void
+
     /// The current route.
     ///
     /// This property must be marked @Published to trigger state changes.
@@ -31,6 +34,15 @@ public protocol StackRouting: ObservableObject {
     /// The parent router, if this router isn't the root of the stack.
     var parent: NestedRouter? { get }
 
+    /// Receive events when the state transitions. Optional.
+    ///
+    /// This is where you should handle any side effects of state transitions,
+    /// because it will properly trigger on both forward (push) and backward
+    /// (pop) transitions.
+    /// 
+    /// Make sure to pass the handler along to child routers if needed.
+    var transition: Transition { get }
+
     /// Construct a new instance of this type, state.
     ///
     /// The returned instance should have its `parent` property set
@@ -41,6 +53,12 @@ public protocol StackRouting: ObservableObject {
     ///
     /// This is how the router transforms state to SwiftUI views.
     func makeContentView(state: State) -> Content
+}
+
+public extension StackRouting {
+
+    /// Default transition handler does nothing.
+    var transition: Transition { { _, _ in } }
 }
 
 /// Adopt this protocol to change how state transitions are presented by default.
@@ -62,29 +80,48 @@ public extension StackRouting {
 
     /// Transition to state with presentation.
     func transition(_ state: State, via presentation: PresentationType) {
+        let oldState = self.state
         presentation.route(self, to: state)
+        let newState = self.state
+        if oldState != newState {
+            transition(oldState, newState)
+        }
     }
 
     /// Transition via presentation, modifying state with closure.
     func transition<Out>(_ presentation: PresentationType, modify: (inout State) throws -> Out) rethrows -> Out {
+        let oldState = state
         var newState = state
         let output = try modify(&newState)
         presentation.route(self, to: newState)
+        if oldState != newState {
+            transition(oldState, newState)
+        }
         return output
     }
 
     /// Pop one level.
     func pop() {
+        let oldState = self.state
         route.pop()
         parent?.route.pop()
+        let newState = parent?.state ?? self.state
+        if oldState != newState {
+            transition(oldState, newState)
+        }
     }
 
     /// Pop to root immediately, skipping each intermediate child.
     func popToRoot() {
         // FIXME: sheets pop the the first child. It seems like a problem
         // in the view, perhaps in SwiftUI.
+        let oldState = self.state
         route.pop()
         rootRouter.route.pop()
+        let newState = rootRouter.state
+        if oldState != newState {
+            transition(oldState, newState)
+        }
     }
 }
 

--- a/Sources/AppRouter/StackRouter.swift
+++ b/Sources/AppRouter/StackRouter.swift
@@ -21,7 +21,7 @@ public protocol StackRouting: ObservableObject {
     associatedtype NestedRouter: StackRouting where NestedRouter == Self
 
     /// A function that receives (oldState, newState) whenever the state changes.
-    typealias Transition = (State, State) -> Void
+    typealias Transition = (_ oldState: Self.State, _ newState: Self.State) -> Void
 
     /// The current route.
     ///
@@ -34,13 +34,13 @@ public protocol StackRouting: ObservableObject {
     /// The parent router, if this router isn't the root of the stack.
     var parent: NestedRouter? { get }
 
-    /// Receive events when the state transitions. Optional.
+    /// Handle events when the state changes. Optional.
     ///
     /// This is where you should handle any side effects of state transitions,
     /// because it will properly trigger on both forward (push) and backward
     /// (pop) transitions.
     /// 
-    /// Make sure to pass the handler along to child routers if needed.
+    /// Make sure to pass the handler to child routers if appropriate.
     var transition: Transition { get }
 
     /// Construct a new instance of this type, state.

--- a/Sources/AppRouter/TabRouter.swift
+++ b/Sources/AppRouter/TabRouter.swift
@@ -26,7 +26,7 @@ public protocol TabRouting: ObservableObject {
     associatedtype TabBarContent: View
 
     /// A function that receives (oldTab, newTab, behavior) whenever the tab changes.
-    typealias Transition = (Tab, Tab, TabBehavior) -> Void
+    typealias Transition = (_ oldTab: Tab, _ newTab: Tab, _ behavior: TabBehavior) -> Void
 
     /// The current route.
     ///
@@ -61,6 +61,12 @@ public protocol TabRouting: ObservableObject {
     /// It's common to want to perform some action when changing to a tab,
     /// generally by using the tab's router via `getStackRouter(tab: newTab)`.
     var transition: Transition { get }
+}
+
+public extension TabRouting {
+
+    /// Default transition handler does nothing.
+    var transition: Transition { { _, _, _ in } }
 }
 
 /// Adopt this protocol to change how tab transitions behave by default.
@@ -112,12 +118,6 @@ public extension TabRouting {
         Binding(get: { self.tab },
                 set: { self.tab = $0 })
     }
-}
-
-public extension TabRouting {
-
-    /// Default transition handler does nothing.
-    var transition: Transition { { _, _, _ in } }
 }
 
 /// The current tab state.

--- a/Tests/AppRouterTests/StackRouterTests.swift
+++ b/Tests/AppRouterTests/StackRouterTests.swift
@@ -230,6 +230,44 @@ class StackRoutingTests: XCTestCase {
 
         XCTAssertEqual(transitions, [])
     }
+
+    func test_link_binding() {
+        let parent = TestRouter(state: 0, transition: transitionHandler)
+
+        parent.transition(1, via: .link)
+
+        XCTAssertEqual(parent.route, StackRoute(base: 0, pushed: 1, presentation: .link))
+        XCTAssertTrue(parent.isLinkActiveBinding.wrappedValue)
+
+        parent.isLinkActiveBinding.wrappedValue = false
+        XCTAssertFalse(parent.isLinkActiveBinding.wrappedValue)
+
+        XCTAssertEqual(parent.route, StackRoute(0))
+
+        XCTAssertEqual(transitions, [
+            StackTransition(0, 1),
+            StackTransition(1, 0)
+        ])
+    }
+
+    func test_sheet_binding() {
+        let parent = TestRouter(state: 0, transition: transitionHandler)
+
+        parent.transition(1, via: .sheet)
+
+        XCTAssertEqual(parent.route, StackRoute(base: 0, pushed: 1, presentation: .sheet))
+        XCTAssertTrue(parent.isSheetPresentedBinding.wrappedValue)
+
+        parent.isSheetPresentedBinding.wrappedValue = false
+        XCTAssertFalse(parent.isSheetPresentedBinding.wrappedValue)
+
+        XCTAssertEqual(parent.route, StackRoute(0))
+
+        XCTAssertEqual(transitions, [
+            StackTransition(0, 1),
+            StackTransition(1, 0)
+        ])
+    }
 }
 
 class PresentableTests: XCTestCase {

--- a/Tests/AppRouterTests/StackRouterTests.swift
+++ b/Tests/AppRouterTests/StackRouterTests.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 class StackRoutingTests: XCTestCase {
 
-    struct Transtion: Equatable, CustomStringConvertible {
+    struct StackTransition: Equatable, CustomStringConvertible {
         init(_ oldState: Int, _ newState: Int) {
             self.oldState = oldState
             self.newState = newState
@@ -30,7 +30,11 @@ class StackRoutingTests: XCTestCase {
         }
 
         var route: StackRoute<Int>
+
+        // Note: the type should be `Transition`, but it fails to compile:
+        // Reference to invalid type alias 'Transition' of type 'StackRoutingTests.TestRouter'
         var transition: (Int, Int) -> Void
+
         var parent: TestRouter?
 
         func makeChildRouter(state: Int) -> TestRouter {
@@ -42,13 +46,13 @@ class StackRoutingTests: XCTestCase {
         }
     }
 
-    var transitions: [Transtion]!
+    var transitions: [StackTransition]!
     var transitionHandler: TestRouter.Transition!
 
     override func setUp() {
         transitions = []
         transitionHandler = {
-            self.transitions.append(Transtion($0, $1))
+            self.transitions.append(StackTransition($0, $1))
         }
     }
 
@@ -68,15 +72,15 @@ class StackRoutingTests: XCTestCase {
         XCTAssertEqual(parent.route, StackRoute(base: 0, pushed: 1, presentation: .link))
 
         XCTAssertEqual(transitions, [
-            Transtion(0, 1)
+            StackTransition(0, 1)
         ])
 
         parent.pop()
         XCTAssertEqual(parent.route, StackRoute(0), "parent drops push")
 
         XCTAssertEqual(transitions, [
-            Transtion(0, 1),
-            Transtion(1, 0)
+            StackTransition(0, 1),
+            StackTransition(1, 0)
         ])
     }
 
@@ -94,8 +98,8 @@ class StackRoutingTests: XCTestCase {
         XCTAssertEqual(child.route, StackRoute(1))
 
         XCTAssertEqual(transitions, [
-            Transtion(0, 1),
-            Transtion(1, 0)
+            StackTransition(0, 1),
+            StackTransition(1, 0)
         ])
     }
 
@@ -124,11 +128,11 @@ class StackRoutingTests: XCTestCase {
         XCTAssertEqual(child3.route, StackRoute(3), "orphaned push is dropped")
 
         XCTAssertEqual(transitions, [
-            Transtion(0, 1),
-            Transtion(1, 2),
-            Transtion(2, 3),
-            Transtion(3, 4),
-            Transtion(4, 2)
+            StackTransition(0, 1),
+            StackTransition(1, 2),
+            StackTransition(2, 3),
+            StackTransition(3, 4),
+            StackTransition(4, 2)
         ])
     }
 
@@ -157,11 +161,11 @@ class StackRoutingTests: XCTestCase {
         XCTAssertEqual(child3.route, StackRoute(3), "orphaned push is dropped")
 
         XCTAssertEqual(transitions, [
-            Transtion(0, 1),
-            Transtion(1, 2),
-            Transtion(2, 3),
-            Transtion(3, 4),
-            Transtion(4, 0)
+            StackTransition(0, 1),
+            StackTransition(1, 2),
+            StackTransition(2, 3),
+            StackTransition(3, 4),
+            StackTransition(4, 0)
         ])
     }
 
@@ -173,7 +177,7 @@ class StackRoutingTests: XCTestCase {
         XCTAssertEqual(parent.route, StackRoute(base: 0, pushed: 1, presentation: .sheet))
 
         XCTAssertEqual(transitions, [
-            Transtion(0, 1)
+            StackTransition(0, 1)
         ])
     }
 
@@ -187,7 +191,7 @@ class StackRoutingTests: XCTestCase {
         XCTAssertEqual(parent.route, StackRoute(base: 0, pushed: 2, presentation: .sheet))
 
         XCTAssertEqual(transitions, [
-            Transtion(0, 2)
+            StackTransition(0, 2)
         ])
     }
 
@@ -203,7 +207,7 @@ class StackRoutingTests: XCTestCase {
         XCTAssertEqual(parent.route, StackRoute(base: 0, pushed: 2, presentation: .sheet))
 
         XCTAssertEqual(transitions, [
-            Transtion(0, 2)
+            StackTransition(0, 2)
         ])
     }
 


### PR DESCRIPTION
This adds a transition event handler for the StackRouter, so you can consistently handle side effects for any state transition. 

Breaking Changes
* TabRouter had an event handler, but it's now a function instead of a method on the protocol